### PR TITLE
Disable Sealed Secrets key renewal

### DIFF
--- a/argocd/k3s/apps/infrastructure/sealed-secrets/application.yaml
+++ b/argocd/k3s/apps/infrastructure/sealed-secrets/application.yaml
@@ -20,6 +20,7 @@ spec:
     helm:
       values: |
         fullnameOverride: sealed-secrets-controller
+        keyrenewperiod: "0"
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
This PR updates the `sealed-secrets` ArgoCD Application manifest to disable the automatic key renewal period by setting the `keyrenewperiod` helm value to `"0"`. This follows the Bitnami Sealed Secrets Helm chart documentation for disabling key renewal.

Fixes #9

---
*PR created automatically by Jules for task [5367256465869521964](https://jules.google.com/task/5367256465869521964) started by @Walkmana-25*