### PR TITLE
Update Victoria Metrics and VMagent storage settings

### DIFF
--- a/argocd/k3s/apps/infrastructure/victoria-metrics/application.yaml
+++ b/argocd/k3s/apps/infrastructure/victoria-metrics/application.yaml
@@ -30,10 +30,14 @@ spec:
               memory: 512Mi
           persistentVolume:
             enabled: true
-            size: 10Gi
-            storageClassName: longhorn
+            size: 32Gi
+            storageClassName: nfs
         vmagent:
           enabled: true
+          persistentVolume:
+            enabled: true
+            size: 2Gi
+            storageClassName: longhorn
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
This change updates the storage configuration for Victoria Metrics in the K3s infrastructure.
The server's persistent volume is switched from Longhorn to NFS and its size is increased from 10GB to 32GB.
Additionally, persistence is enabled for VMagent with a 2GB volume using the Longhorn storage class.

Fixes #11

---
*PR created automatically by Jules for task [5777670727712510919](https://jules.google.com/task/5777670727712510919) started by @Walkmana-25*