### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ansible-check.yml
+++ b/.github/workflows/ansible-check.yml
@@ -11,6 +11,9 @@ on:
         required: false
         default: 'main'
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Walkmana-25/homelab/security/code-scanning/7](https://github.com/Walkmana-25/homelab/security/code-scanning/7)

Add an explicit `permissions` block in `.github/workflows/ansible-check.yml` to enforce least privilege for `GITHUB_TOKEN`.

Best fix (without changing workflow behavior): define permissions at the workflow root so it applies to all jobs unless overridden. For this workflow, `contents: read` is sufficient for checkout and read-only CI tasks.

**Where to change:**
- File: `.github/workflows/ansible-check.yml`
- Insert directly after the trigger section (`on:` block) and before `jobs:`.

No imports, methods, or dependencies are needed; this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
