### PR TITLE
Add health endpoint to FastMCP proxy

### DIFF
--- a/k8s/apps/mcp-proxy/configmap.yaml
+++ b/k8s/apps/mcp-proxy/configmap.yaml
@@ -8,6 +8,7 @@ data:
   proxy.py: |
     from fastmcp import FastMCP
     from fastmcp.server import create_proxy
+    from starlette.responses import JSONResponse
 
 
     # --- MCP upstream servers configuration ---
@@ -54,6 +55,11 @@ data:
         transport="streamable-http",
         path="/mcp",
     )
+
+    async def health(request):
+        return JSONResponse({"status": "ok"})
+
+    app.add_route("/health", health, methods=["GET"])
 
 
     if __name__ == "__main__":

--- a/k8s/apps/mcp-proxy/deployment.yaml
+++ b/k8s/apps/mcp-proxy/deployment.yaml
@@ -80,20 +80,20 @@ spec:
               memory: 256Mi
           startupProbe:
             httpGet:
-              path: /mcp
+              path: /health
               port: 9090
             initialDelaySeconds: 30
             periodSeconds: 5
             failureThreshold: 30
           livenessProbe:
             httpGet:
-              path: /mcp
+              path: /health
               port: 9090
             periodSeconds: 30
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /mcp
+              path: /health
               port: 9090
             periodSeconds: 10
             failureThreshold: 3

--- a/k8s/apps/mcp-proxy/nginx-configmap.yaml
+++ b/k8s/apps/mcp-proxy/nginx-configmap.yaml
@@ -24,6 +24,14 @@ data:
     server {
         listen 8080;
 
+        location = /health {
+            proxy_pass http://127.0.0.1:9090/health;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location / {
             set $auth_ok 0;
             if ($auth_header_valid = 1) {


### PR DESCRIPTION
This change adds a dedicated health check endpoint to the MCP proxy application and updates the Kubernetes deployment to use it for liveness and readiness probes. This improves health monitoring and ensures the proxy is properly initialized before receiving traffic.

Fixes #14

---
*PR created automatically by Jules for task [16312533525555027729](https://jules.google.com/task/16312533525555027729) started by @Walkmana-25*