### PR TITLE
Fix ArgoCD manifest validation failure for Cluster resource

### DIFF
--- a/argocd/Makefile
+++ b/argocd/Makefile
@@ -35,8 +35,9 @@ validate-manifests: ## Validate ArgoCD Application manifests with kubeconform
 	@for dir in $(shell find $(APPS_DIR) -name 'kustomization.yaml' -exec dirname {} \;); do \
 		echo "  Validating $$dir..."; \
 		kustomize build $$dir | kubeconform \
+			-schema-location 'default' \
 			-schema-location 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}-standalone{{.KindSuffix}}/{{.ResourceKind}}.json' \
-			-skip 'Application,IPAddressPool,L2Advertisement,SealedSecret,ConfigMap,Ingress' \
+			-skip 'Application,Cluster,IPAddressPool,L2Advertisement,SealedSecret,ConfigMap,Ingress' \
 			-strict || exit 1; \
 	done
 	@echo "  All manifests validated!"


### PR DESCRIPTION
The `argocd check` (specifically `validate-manifests`) was failing because `kubeconform` could not find the JSON schema for the `Cluster` resource type used by CloudNativePG. 

To fix this, I:
1. Added `Cluster` to the `-skip` list in the `validate-manifests` target in `argocd/Makefile`, following the existing pattern for other Custom Resources like `SealedSecret` and `Application`.
2. Added `-schema-location 'default'` to the `kubeconform` command. This ensures that even when custom schema locations are provided, `kubeconform` can still fall back to its internal schemas for standard Kubernetes objects (like `Secret`), which prevented further validation errors during testing.

Verified the fix by running `make -C argocd validate-manifests` locally after installing `kustomize` and `kubeconform`.

Fixes #17

---
*PR created automatically by Jules for task [10375037226102088230](https://jules.google.com/task/10375037226102088230) started by @Walkmana-25*